### PR TITLE
Add corporate site pages

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="bg-gray-800 text-white mt-12">
+      <div className="container mx-auto p-4 text-center text-sm">
+        &copy; {new Date().getFullYear()} MyCorp. All rights reserved.
+      </div>
+    </footer>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="bg-gray-800 text-white">
+      <div className="container mx-auto flex justify-between items-center p-4">
+        <Link href="/">
+          <span className="font-bold text-lg">MyCorp</span>
+        </Link>
+        <nav className="space-x-4">
+          <Link href="/about">About</Link>
+          <Link href="/services">Services</Link>
+          <Link href="/projects">Projects</Link>
+          <Link href="/contact">Contact</Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+import Header from './Header';
+import Footer from './Footer';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow container mx-auto p-4">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,14 @@
 // pages/_app.tsx
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
+import Layout from '@/components/Layout';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
 }
 
 export default MyApp;

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,18 @@
+export default function About() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold mb-4">About Us</h1>
+      <p>
+        We are an offshore development company providing high quality services with Japanese project
+        management.
+      </p>
+      <h2 className="text-2xl font-semibold">Company Info</h2>
+      <ul className="list-disc list-inside">
+        <li>Company Name: MyCorp Inc.</li>
+        <li>Founded: 2020</li>
+        <li>Capital: 10M JPY</li>
+        <li>CEO: Taro Yamada</li>
+      </ul>
+    </div>
+  );
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,28 @@
+export default function Contact() {
+  return (
+    <div className="space-y-6 max-w-xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+      <form className="space-y-4">
+        <div>
+          <label className="block mb-1 font-medium">Name</label>
+          <input type="text" className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 font-medium">Company</label>
+          <input type="text" className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 font-medium">Email</label>
+          <input type="email" className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 font-medium">Message</label>
+          <textarea className="w-full border p-2 rounded" rows={4}></textarea>
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div className="space-y-12">
+      <section className="text-center py-20 bg-gray-100 rounded">
+        <h1 className="text-4xl font-bold mb-4">Welcome to MyCorp</h1>
+        <p className="mb-6">
+          Offshore development with Japanese direction for cost savings and quality.
+        </p>
+        <Link href="/contact" className="bg-blue-600 text-white px-4 py-2 rounded">
+          Contact Us
+        </Link>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Our Strengths</h2>
+        <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <li className="p-4 border rounded">Cost effective</li>
+          <li className="p-4 border rounded">High quality</li>
+          <li className="p-4 border rounded">Fast delivery</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Services</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="border p-4 rounded">
+            <h3 className="font-bold">Service A</h3>
+            <p>Short description</p>
+            <Link href="/services" className="text-blue-600">
+              Learn more
+            </Link>
+          </div>
+          <div className="border p-4 rounded">
+            <h3 className="font-bold">Service B</h3>
+            <p>Short description</p>
+            <Link href="/services" className="text-blue-600">
+              Learn more
+            </Link>
+          </div>
+          <div className="border p-4 rounded">
+            <h3 className="font-bold">Service C</h3>
+            <p>Short description</p>
+            <Link href="/services" className="text-blue-600">
+              Learn more
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="text-center bg-gray-100 p-8 rounded">
+        <h2 className="text-2xl font-semibold mb-4">Need Help?</h2>
+        <p className="mb-4">Get in touch for consultation and estimation.</p>
+        <Link href="/contact" className="bg-blue-600 text-white px-4 py-2 rounded">
+          Contact Us
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -1,0 +1,13 @@
+export default function Projects() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Projects</h1>
+      <p>Here are some of our recent works.</p>
+      <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <li className="border p-4 rounded">Project A - E-commerce site</li>
+        <li className="border p-4 rounded">Project B - AI Chatbot</li>
+        <li className="border p-4 rounded">Project C - Mobile App</li>
+      </ul>
+    </div>
+  );
+}

--- a/pages/services.tsx
+++ b/pages/services.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+
+export default function Services() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Our Services</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="border p-4 rounded">
+          <h2 className="font-semibold">AI Chat Integration</h2>
+          <p className="mb-2">Implement chatbots with AI.</p>
+          <Link href="/solutions/ai-chat" className="text-blue-600">
+            Details
+          </Link>
+        </div>
+        <div className="border p-4 rounded">
+          <h2 className="font-semibold">Offshore Consulting</h2>
+          <p className="mb-2">Expert guidance for offshore projects.</p>
+          <Link href="/solutions/offshore-dev" className="text-blue-600">
+            Details
+          </Link>
+        </div>
+        <div className="border p-4 rounded">
+          <h2 className="font-semibold">SaaS Development</h2>
+          <p className="mb-2">Full-cycle SaaS product development.</p>
+          <Link href="/solutions/saas" className="text-blue-600">
+            Details
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/solutions/ai-chat.tsx
+++ b/pages/solutions/ai-chat.tsx
@@ -1,0 +1,14 @@
+export default function AiChat() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold mb-4">AI Chat Solution</h1>
+      <p>Automate customer support with AI chatbots.</p>
+      <h2 className="text-2xl font-semibold">Benefits</h2>
+      <ul className="list-disc list-inside">
+        <li>24/7 response</li>
+        <li>Reduced costs</li>
+        <li>Improved customer satisfaction</li>
+      </ul>
+    </div>
+  );
+}

--- a/pages/solutions/offshore-dev.tsx
+++ b/pages/solutions/offshore-dev.tsx
@@ -1,0 +1,8 @@
+export default function OffshoreDev() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Offshore Development</h1>
+      <p>Consulting and project execution with cost-effective offshore teams.</p>
+    </div>
+  );
+}

--- a/pages/solutions/saas.tsx
+++ b/pages/solutions/saas.tsx
@@ -1,0 +1,8 @@
+export default function SaaS() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold mb-4">SaaS Development</h1>
+      <p>Complete development service for your SaaS ideas.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add layout with header and footer
- include layout in `_app`
- scaffold top, about, services, projects, contact pages
- create example solution pages

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_683bccc98fe8832aac16653cf731a673